### PR TITLE
add show tables command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ ddbpartiql> update "ddb-test-table"
 ddbpartiql> delete from "ddb-test-table" where id=10 and name='name1';
 ```
 
+#### Show Tables(extension query)
+
+```bash
+ddbpartiql> show tables;
+```
+
 #### Describe Table(extension query)
 
 ```bash

--- a/src/database.ts
+++ b/src/database.ts
@@ -8,6 +8,8 @@ import {
     DeleteTableCommand,
     DeleteTableCommandOutput,
     ResourceNotFoundException,
+		ListTablesCommand,
+		ListTablesCommandOutput,
 } from "@aws-sdk/client-dynamodb";
 import {
     DynamoDBDocumentClient,
@@ -209,4 +211,14 @@ export default class DynamoDBAccessor {
 
         return response;
     }
+
+		async showTables(
+			lastEvaluatedTableName: string
+		): Promise<ListTablesCommandOutput> {
+			const command = new ListTablesCommand({
+				ExclusiveStartTableName: lastEvaluatedTableName,
+			});
+			const response = await this.docClient.send(command);
+			return response;
+		}
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -8,8 +8,8 @@ import {
     DeleteTableCommand,
     DeleteTableCommandOutput,
     ResourceNotFoundException,
-		ListTablesCommand,
-		ListTablesCommandOutput,
+    ListTablesCommand,
+    ListTablesCommandOutput,
 } from "@aws-sdk/client-dynamodb";
 import {
     DynamoDBDocumentClient,
@@ -212,13 +212,13 @@ export default class DynamoDBAccessor {
         return response;
     }
 
-		async showTables(
-			lastEvaluatedTableName: string
-		): Promise<ListTablesCommandOutput> {
-			const command = new ListTablesCommand({
-				ExclusiveStartTableName: lastEvaluatedTableName,
-			});
-			const response = await this.docClient.send(command);
-			return response;
-		}
+    async showTables(
+      lastEvaluatedTableName: string
+    ): Promise<ListTablesCommandOutput> {
+      const command = new ListTablesCommand({
+        ExclusiveStartTableName: lastEvaluatedTableName,
+      });
+      const response = await this.docClient.send(command);
+      return response;
+    }
 }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -451,53 +451,53 @@ async function executeVariable(cmd: string): Promise<boolean> {
 }
 
 async function executeShowTables(
-	db: DynamoDBAccessor,
-	cmd: string
+  db: DynamoDBAccessor,
+  cmd: string
 ): Promise<boolean> {
-	let originCmd = cmd;
-	cmd = convertVariables(cmd, variables);
-	const lex = new Lex(cmd);
-	let txt = lex.next();
-	if (txt.toUpperCase() != "SHOW") {
-			console.error("show tables query error");
-			return false;
-	}
-	txt = lex.next();
-	if (txt.toUpperCase() != "TABLES") {
-		console.error("show tables query error");
-		return false;
-	}
-	txt = lex.next();
-	if (txt != ";") {
-			console.error("show tables syntax error [%s]", cmd);
-			return false;
-	}
-	try {
-			console.log(cmd);
-			let lastEvaluatedTableName = undefined;
-			while(true){
-				let response = await db.showTables(lastEvaluatedTableName);
-				if (response == undefined) {
-					throw new Error("show tables returned an unexpected response");
-				}
-				const meta = response["$metadata"];
-				console.log("http status code: ", meta.httpStatusCode);
-				if (response.TableNames != undefined) {
-						console.log(JSON.stringify(response.TableNames, null, 2));
-				}
-				if(response.LastEvaluatedTableName != undefined){
-					lastEvaluatedTableName = response.LastEvaluatedTableName;
-				} else {
-					break;
-				}
-			}
-			addHistory(originCmd);
-	} catch (e) {
-			console.error(e.toString());
-			return false;
-	}
+  let originCmd = cmd;
+  cmd = convertVariables(cmd, variables);
+  const lex = new Lex(cmd);
+  let txt = lex.next();
+  if (txt.toUpperCase() != "SHOW") {
+      console.error("show tables query error");
+      return false;
+  }
+  txt = lex.next();
+  if (txt.toUpperCase() != "TABLES") {
+    console.error("show tables query error");
+    return false;
+  }
+  txt = lex.next();
+  if (txt != ";") {
+      console.error("show tables syntax error [%s]", cmd);
+      return false;
+  }
+  try {
+      console.log(cmd);
+      let lastEvaluatedTableName = undefined;
+      while(true){
+        let response = await db.showTables(lastEvaluatedTableName);
+        if (response == undefined) {
+          throw new Error("show tables returned an unexpected response");
+        }
+        const meta = response["$metadata"];
+        console.log("http status code: ", meta.httpStatusCode);
+        if (response.TableNames != undefined) {
+            console.log(JSON.stringify(response.TableNames, null, 2));
+        }
+        if(response.LastEvaluatedTableName != undefined){
+          lastEvaluatedTableName = response.LastEvaluatedTableName;
+        } else {
+          break;
+        }
+      }
+      addHistory(originCmd);
+  } catch (e) {
+      console.error(e.toString());
+      return false;
+  }
 
-	return true;
+  return true;
 }
 
 async function executeCommand(
@@ -518,8 +518,8 @@ async function executeCommand(
         ret = await executeCreateTable(db, cmd);
     } else if (cmd.startsWith("drop") || cmd.startsWith("DROP")) {
         ret = await executeDeleteTable(db, cmd);
-		} else if (cmd.startsWith("show") || cmd.startsWith("SHOW")) {
-				ret = await executeShowTables(db, cmd);
+    } else if (cmd.startsWith("show") || cmd.startsWith("SHOW")) {
+        ret = await executeShowTables(db, cmd);
     } else {
         ret = await executePartiQL(db, cmd, option);
     }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -450,6 +450,56 @@ async function executeVariable(cmd: string): Promise<boolean> {
     return true;
 }
 
+async function executeShowTables(
+	db: DynamoDBAccessor,
+	cmd: string
+): Promise<boolean> {
+	let originCmd = cmd;
+	cmd = convertVariables(cmd, variables);
+	const lex = new Lex(cmd);
+	let txt = lex.next();
+	if (txt.toUpperCase() != "SHOW") {
+			console.error("show tables query error");
+			return false;
+	}
+	txt = lex.next();
+	if (txt.toUpperCase() != "TABLES") {
+		console.error("show tables query error");
+		return false;
+	}
+	txt = lex.next();
+	if (txt != ";") {
+			console.error("show tables syntax error [%s]", cmd);
+			return false;
+	}
+	try {
+			console.log(cmd);
+			let lastEvaluatedTableName = undefined;
+			while(true){
+				let response = await db.showTables(lastEvaluatedTableName);
+				if (response == undefined) {
+					throw new Error("show tables returned an unexpected response");
+				}
+				const meta = response["$metadata"];
+				console.log("http status code: ", meta.httpStatusCode);
+				if (response.TableNames != undefined) {
+						console.log(JSON.stringify(response.TableNames, null, 2));
+				}
+				if(response.LastEvaluatedTableName != undefined){
+					lastEvaluatedTableName = response.LastEvaluatedTableName;
+				} else {
+					break;
+				}
+			}
+			addHistory(originCmd);
+	} catch (e) {
+			console.error(e.toString());
+			return false;
+	}
+
+	return true;
+}
+
 async function executeCommand(
     db: DynamoDBAccessor,
     cmd: string,
@@ -468,6 +518,8 @@ async function executeCommand(
         ret = await executeCreateTable(db, cmd);
     } else if (cmd.startsWith("drop") || cmd.startsWith("DROP")) {
         ret = await executeDeleteTable(db, cmd);
+		} else if (cmd.startsWith("show") || cmd.startsWith("SHOW")) {
+				ret = await executeShowTables(db, cmd);
     } else {
         ret = await executePartiQL(db, cmd, option);
     }


### PR DESCRIPTION
現在のアカウントとエンドポイントに関連付けられたテーブル名の配列を返すように、下記コマンドを追加しました
```bash
ddbpartiql> show tables;
```